### PR TITLE
Select the best-available display mode for mtr

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"regexp"
 	"sync"
 	"time"
 
@@ -179,8 +178,6 @@ func (a *analyzer) createStoreCommand(
 	}
 }
 
-var hasJSONRE = regexp.MustCompile("--json")
-var hasReportWideRE = regexp.MustCompile("--report-wide")
 func (a *analyzer) mtrCommands() []func() {
 	// Determine what options the machine's mtr offers
 	cmd := exec.Command("mtr", "--help") // nolint: gas, gosec
@@ -193,10 +190,10 @@ func (a *analyzer) mtrCommands() []func() {
 	// mtr capabilities.
 	var displayArgs []string
 	var fileExt string
-	if (hasJSONRE.Match(output)) {
+	if (bytes.Contains(output, []byte("--json"))) {
 		displayArgs = []string{"--json"}
 		fileExt = "json"
-	} else if (hasReportWideRE.Match(output)) {
+	} else if (bytes.Contains(output, []byte("--report-wide"))) {
 		displayArgs = []string{"--report-wide"}
 		fileExt = "txt"
 	} else {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"sync"
 	"time"
 
@@ -74,14 +75,15 @@ func main() {
 
 		a.createStoreCommand("ip-addr.txt", "ip", "addr"),
 		a.createStoreCommand("ip-route.txt", "ip", "route"),
-		a.createStoreCommand(host+"-mtr-ipv4.json", "mtr", "-j", "-4", host),
-		a.createStoreCommand(host+"-mtr-ipv6.json", "mtr", "-j", "-6", host),
+
 		a.createStoreCommand(host+"-ping-ipv4.txt", "ping", "-4", "-c", "30", host),
 		a.createStoreCommand(host+"-ping-ipv6.txt", "ping", "-6", "-c", "30", host),
 		a.createStoreCommand(host+"-tracepath.txt", "tracepath", host),
 		a.addIP,
 		a.addResolvConf,
 	}
+
+	tasks = append(tasks, a.mtrCommands()...)
 
 	var wg sync.WaitGroup
 	for _, task := range tasks {
@@ -174,6 +176,37 @@ func (a *analyzer) createStoreCommand(
 			a.storeError(errors.Wrapf(err, "error getting data for %s", f))
 		}
 		a.storeFile(f, output)
+	}
+}
+
+var hasJSONRE = regexp.MustCompile("--json")
+var hasReportWideRE = regexp.MustCompile("--report-wide")
+func (a *analyzer) mtrCommands() []func() {
+	// Determine what options the machine's mtr offers
+	cmd := exec.Command("mtr", "--help") // nolint: gas, gosec
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		a.storeError(errors.Wrapf(err, "error determining mtr command"))
+	}
+
+	// Select the display mode and file extension based on the machine's
+	// mtr capabilities.
+	var displayArgs []string
+	var fileExt string
+	if (hasJSONRE.Match(output)) {
+		displayArgs = []string{"--json"}
+		fileExt = "json"
+	} else if (hasReportWideRE.Match(output)) {
+		displayArgs = []string{"--report-wide"}
+		fileExt = "txt"
+	} else {
+		displayArgs = []string{"--report", "--no-dns"}
+		fileExt = "txt"
+	}
+
+	return []func(){
+		a.createStoreCommand(host+"-mtr-ipv4."+fileExt, "mtr", append(displayArgs, "-4", host)...),
+		a.createStoreCommand(host+"-mtr-ipv6."+fileExt, "mtr", append(displayArgs, "-6", host)...),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -183,7 +183,8 @@ func (a *analyzer) mtrCommands() []func() {
 	cmd := exec.Command("mtr", "--help") // nolint: gas, gosec
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		a.storeError(errors.Wrapf(err, "error determining mtr command"))
+		a.storeError(errors.Wrapf(err, "error determining mtr command: %s", output))
+		return []func(){}
 	}
 
 	// Select the display mode and file extension based on the machine's


### PR DESCRIPTION
It has been discovered that `--json` is not available on all versions of `mtr` that run on current OSs. This PR introduces a check for what display modes are available from the machine's version of `mtr`, and uses the best one it finds. It will select the first available from the following list:

* `--json` (available since `mtr` version 0.87, 3 Aug 2016)
* `--report-wide` (available since `mtr` version 0.75, 18 Sep 2008)
* `--report --no-dns`(available since `mtr` version 0.21 (or earlier) and 0.26 respectively, both October 1998)